### PR TITLE
Allow for images with query parameters

### DIFF
--- a/widget/lib/jquery.ui.rlightbox.js
+++ b/widget/lib/jquery.ui.rlightbox.js
@@ -253,7 +253,7 @@ $.extend($.ui.rlightbox, {
 						type: "youtube"
 					},
 					image: {
-						urls: [/.jpg$|.png$|.gif$/],
+						urls: [/(\.jpg|\.png|\.gif)(\?.*)?$/],
 						type: "image"
 					},
 					vimeo: {


### PR DESCRIPTION
I am using s3 and I need to pass tokens (access key, etc) via a query string in the url and it was causing it to be excluded from the lightbox. I adjusted the regular expression to allow for query strings but still check for the image extensions (.jpg, .png, .gif).

Thanks!
Kevin
